### PR TITLE
Remove deprecated curl argument in biomaRt::getBM()

### DIFF
--- a/R/toolkit.R
+++ b/R/toolkit.R
@@ -151,8 +151,7 @@ sampleEnsemblGeneId <- function(dataset, curl=getCurlHandle()){
     # query the first (automatically non-empty) ensembl_gene_id
     ensembl_gene_id <- getBM(
         attributes="ensembl_gene_id",
-        mart=mart.loop,
-        curl=curl
+        mart=mart.loop
         )[1,"ensembl_gene_id"]
     # return the above ensembl_gene_id
     return(ensembl_gene_id)
@@ -211,8 +210,7 @@ microarray2dataset.build <- function(){
             # Query the first (automatically non-empty) ensembl_gene_id
             probe.set = getBM(
                 attributes=microarray.header,
-                mart=mart.loop,
-                curl=curlHandle
+                mart=mart.loop
                 )[1,microarray.header]
             getBM.results <- rbind(
                 getBM.results,


### PR DESCRIPTION
Fix R CMD check WARNING.

Removed in https://github.com/Huber-group-EMBL/biomaRt/commit/413485c86924f6cfde1390948678fd08ea2bb9a8.

Checks: https://bioconductor.org/checkResults/release/bioc-LATEST/GOexpress/

An additional change might be to deprecate the curl argument here as well since it's no longer used but the minimal change at least ensures the WARNING is fixed.